### PR TITLE
fix: Improve unstable content model download

### DIFF
--- a/bin/download-content-model.js
+++ b/bin/download-content-model.js
@@ -1,16 +1,51 @@
-const clone = require('git-clone')
-const path = require('path')
+'use strict'
 
-console.log('Cloning content model');
-clone(
-  'git@github.com:contentful/content-models.git',
-  path.resolve(__dirname, '..', 'data'),
-  (error) => {
-    if (error) {
-      console.log('An error happend during cloning')
-      console.log(error)
-    }
+const fetch = require('node-fetch')
+const zlib = require('zlib')
+const tar = require('tar')
+const ctfImport = require('contentful-import')
+const argv = require('yargs').argv
+const log = require('npmlog')
 
-    console.log('Cloned data to ./data')
-  }
-)
+if (!argv.spaceId || !argv.managementToken) {
+  throw new Error(`
+    Please define your space id and your content management API access token
+
+    E.g.
+      $ npm run import-data -- --space-id 123456 --management-token abcdef
+  `)
+}
+
+log.info('Downloading blog content model')
+fetch('https://api.github.com/repos/contentful/content-models/releases/latest')
+  .then(res => res.json())
+  .then(res => {
+    return fetch(res.tarball_url)
+  })
+  .then(res => {
+    return new Promise((resolve, reject) => {
+      log.info('Unpacking blog content model')
+      res.body
+        .pipe(zlib.Unzip())
+        .pipe(new tar.Unpack({
+          cwd: '/data',
+          strip: 1
+        }))
+        .on('error', reject)
+        .on('close', resolve)
+    })
+  })
+  .then(_ => {
+    log.info('Importing blog content model')
+    return ctfImport(
+      {
+        content: require('../data/blog/contentful-export.json'),
+        spaceId: argv.spaceId,
+        managementToken: argv.managementToken
+      }
+    )
+  })
+  .then(_ => {
+    log.info(`Your space is now ready to use`)
+  })
+  .catch(console.log)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -6,7 +6,7 @@ To get you started you have to be registered at [Contentful](https://www.content
 
 ```bash
 $ git clone git@github.com:contentful/blog-in-5-minutes.git
-
+$ cd blog-in-5-minutes
 $ npm install
 ```
 
@@ -77,7 +77,12 @@ To see the site working with your newly created data all you have to do is to ru
 
 ## Deploy the site to `now`
 
-`now` is a fairly new service by [zeit](https://zeit.co), which also provides static hosting. If you run `npm run deploy` you're asked for your email adress (which you have to confirm) once and then your site will find its way into the cloud.
+`now` is a fairly new service by [zeit](https://zeit.co), which also provides static hosting.
+
+If you haven't used it yet please run `npm run login` to register at zeit.
+This will take you only one minute.
+
+If you then run `npm run deploy` your site will find its way into the cloud.
 
 ```bash
 $ npm run deploy

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "generate": "nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "precommit": "npm run lint",
+    "login": "now login",
     "deploy": "nuxt generate && now dist",
-    "import-data": "node ./bin/download-content-model.js && contentful-import --content-file ./data/blog/contentful-export.json"
+    "import-data": "node ./bin/download-content-model.js"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
@@ -31,8 +32,12 @@
     "eslint-plugin-promise": "^3.4.1",
     "eslint-plugin-standard": "^2.0.1",
     "gh-pages": "^1.0.0",
-    "git-clone": "^0.1.0",
-    "now": "^5.3.0"
+    "node-fetch": "^1.7.0",
+    "now": "^5.3.0",
+    "npmlog": "^4.1.0",
+    "tar": "^3.1.3",
+    "yargs": "^8.0.1",
+    "zlib": "^1.0.5"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This PR improves the download of the content model (shamelessly borrowed from the CLI tool) and also adds another command `npm run login` to make the deployment flow easier to grasp for people not being registered at zeit.