### PR TITLE
fix(build): fix font reference

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -22,7 +22,7 @@
     font-family: "Avenir";
     font-weight: 400;
     font-style: normal;
-    src: url("/avenir-400.woff2") format("woff2");
+    src: url("~/static/avenir-400.woff2") format("woff2");
     font-display: swap;
   }
 


### PR DESCRIPTION
Currently when passing the guide running `npm run dev` afterwards this webpack error appears.

```
 ERROR  Failed to compile with 1 errors                                 21:26:18

This dependency was not found:

* avenir-400.woff2 in ./node_modules/css-loader?{"minimize":true,"importLoaders":1,"sourceMap":true,"root":"~","alias":{"/static":"/Users/stefanjudis/Projects/cf-blog-in-5-minutes/static","/assets":"/Users/stefanjudis/Projects/cf-blog-in-5-minutes/assets"}}!./node_modules/vue-loader/lib/style-compiler?{"vue":true,"id":"data-v-610e013a","scoped":false,"hasInlineConfig":true}!./node_modules/vue-loader/lib/selector.js?type=styles&index=0!./layouts/default.vue

To install it, you can run: npm install --save avenir-400.woff2
^C%

```

This PR fixes this.